### PR TITLE
feat: Homeserver Observer

### DIFF
--- a/src/infrastructure/http/server.rs
+++ b/src/infrastructure/http/server.rs
@@ -9,6 +9,7 @@ use crate::{
         http::HttpServerError,
         sql::{DbError, SqlDb},
     },
+    shared::HomeserverObserver,
     sms_verification::http::router,
 };
 
@@ -31,6 +32,8 @@ impl HttpServer {
     }
 
     pub async fn start(config: EnvConfig) -> Result<Self, HttpServerError> {
+        HomeserverObserver::spawn_crash_on_unresponsive_homeserver(&config).await;
+
         let db = SqlDb::connect(&config.database_url)
             .await
             .map_err(DbError::from)?;

--- a/src/shared/homeserver_admin_api.rs
+++ b/src/shared/homeserver_admin_api.rs
@@ -36,4 +36,30 @@ impl HomeserverAdminAPI {
     pub fn get_homeserver_pubky(&self) -> String {
         self.homeserver_pubky.clone()
     }
+
+    /// Verifies the admin password by making a GET request to the /info endpoint.
+    /// This request might take a moment.
+    pub async fn verify_password(&self) -> Result<(), reqwest::Error> {
+        let url = self
+            .base_url
+            .join("/info")
+            .expect("Failed to join URL path");
+        let response = self
+            .http_client
+            .get(url)
+            .header("X-Admin-Password", &self.admin_password)
+            .send()
+            .await?;
+        response.error_for_status()?;
+        Ok(())
+    }
+
+    /// Checks if the homeserver is responsive by making a GET request to the root URL
+    /// This is NOT password protected so it won't validate the admin password.
+    pub async fn health_check(&self) -> Result<(), reqwest::Error> {
+        let url = self.base_url.join("/").expect("Failed to join URL path");
+        let response = self.http_client.get(url).send().await?;
+        response.error_for_status()?;
+        Ok(())
+    }
 }

--- a/src/shared/homeserver_observer.rs
+++ b/src/shared/homeserver_observer.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use crate::{EnvConfig, shared::HomeserverAdminAPI};
+
+/// Observer for the homeserver admin API
+/// This is used to check if the homeserver is running and responsive
+/// If it is not responsive, we'll crash the server
+pub struct HomeserverObserver {
+    admin_api: HomeserverAdminAPI,
+}
+
+impl HomeserverObserver {
+    pub fn new(admin_api: HomeserverAdminAPI) -> Self {
+        Self { admin_api }
+    }
+
+    /// Continuously checks if the homeserver is responsive and errors if it is not
+    /// This is used to ensure that the homeserver is always responsive
+    /// This method is blocking.
+    pub async fn err_on_unresponsive(&self) -> Result<(), reqwest::Error> {
+        let mut i = 0;
+        loop {
+            i += 1;
+            let should_do_password_check = i % 60 == 0; // Occasional expensive password check to verify the admin password is correct.
+            if should_do_password_check {
+                self.admin_api.verify_password().await?;
+            } else {
+                self.admin_api.health_check().await?;
+            }
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+    }
+
+    /// Spawns a task to continuously check if the homeserver is responsive.
+    /// This will crash the server if the homeserver is not responsive.
+    /// This is to ensure that homegate does not hand out lightning invoices to users if we can't generate signup tokens.
+    pub async fn spawn_crash_on_unresponsive_homeserver(config: &EnvConfig) {
+        let homeserver_admin_api = HomeserverAdminAPI::new(
+            &config.homeserver_admin_api_url,
+            &config.homeserver_admin_password,
+            &config.homeserver_pubky,
+        );
+
+        // Check homeserver password to prevent the server from starting if the homeserver is not responsive/password is incorrect.
+        if let Err(e) = homeserver_admin_api.verify_password().await {
+            tracing::error!(
+                "Homeserver connection failed: {:?}. Stopping server because the homeserver is a critical dependency.",
+                e
+            );
+            std::process::exit(1);
+        }
+
+        // Continuously check if the homeserver is responsive in the background.
+        let homeserver_observer = HomeserverObserver::new(homeserver_admin_api);
+        tokio::spawn(async move {
+            if let Err(e) = homeserver_observer.err_on_unresponsive().await {
+                tracing::error!("Homeserver is not responsive: {:?}", e);
+                tracing::error!("Shutting down server due to homeserver being unresponsive");
+                std::process::exit(1);
+            }
+        });
+    }
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,3 +1,5 @@
 mod homeserver_admin_api;
+mod homeserver_observer;
 
 pub use homeserver_admin_api::HomeserverAdminAPI;
+pub use homeserver_observer::HomeserverObserver;


### PR DESCRIPTION
Adds a background task to homegate that continuously calls the homeserver and crashes homegate in case the homeserver is unreachable. This is to prevent handing out LN/SMS verifications without being able to generate a signup token.