### PR TITLE
feat: Increase amount of client data sent to Prelude

### DIFF
--- a/src/infrastructure/http/extractors.rs
+++ b/src/infrastructure/http/extractors.rs
@@ -48,6 +48,32 @@ where
     }
 }
 
+/// Axum extractor for User-Agent header
+///
+/// Extracts the User-Agent header from HTTP requests.
+/// Returns None if the header is missing or cannot be parsed as a valid string.
+pub struct UserAgent(pub Option<String>);
+
+impl<S> FromRequestParts<S> for UserAgent
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let headers = HeaderMap::from_request_parts(parts, state)
+            .await
+            .expect("HeaderMap extractor should never fail");
+
+        let user_agent = headers
+            .get("user-agent")
+            .and_then(|hv| hv.to_str().ok())
+            .map(|s| s.to_string());
+
+        Ok(UserAgent(user_agent))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -172,5 +198,28 @@ mod tests {
             .unwrap();
         // Should trim whitespace
         assert_eq!(result, "203.0.113.1".parse::<IpAddr>().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_user_agent_present() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "user-agent",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+                .parse()
+                .unwrap(),
+        );
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+
+        let request = make_request(headers, addr);
+        let (mut parts, _) = request.into_parts();
+        let UserAgent(result) = UserAgent::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            Some("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36".to_string())
+        );
     }
 }

--- a/src/infrastructure/http/extractors/mod.rs
+++ b/src/infrastructure/http/extractors/mod.rs
@@ -1,0 +1,2 @@
+pub mod request_origin;
+pub mod user_agent;

--- a/src/infrastructure/http/extractors/request_origin.rs
+++ b/src/infrastructure/http/extractors/request_origin.rs
@@ -35,42 +35,19 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let headers = HeaderMap::from_request_parts(parts, state)
+        let headers = HeaderMap::from_request_parts(parts, state).await?;
+
+        let addr = ConnectInfo::<SocketAddr>::from_request_parts(parts, state)
             .await
-            .expect("HeaderMap extractor should never fail");
-        let ConnectInfo(addr) = ConnectInfo::<SocketAddr>::from_request_parts(parts, state)
-            .await
-            .expect("ConnectInfo extractor should never fail");
+            .ok()
+            .map(|ConnectInfo(addr)| addr);
+
         let ip = maybe_x_forwarded_for(&headers)
             .or_else(|| maybe_x_real_ip(&headers))
-            .unwrap_or_else(|| addr.ip());
+            .or_else(|| addr.map(|a| a.ip()))
+            .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+
         Ok(RequestOrigin(ip))
-    }
-}
-
-/// Axum extractor for User-Agent header
-///
-/// Extracts the User-Agent header from HTTP requests.
-/// Returns None if the header is missing or cannot be parsed as a valid string.
-pub struct UserAgent(pub Option<String>);
-
-impl<S> FromRequestParts<S> for UserAgent
-where
-    S: Send + Sync,
-{
-    type Rejection = std::convert::Infallible;
-
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let headers = HeaderMap::from_request_parts(parts, state)
-            .await
-            .expect("HeaderMap extractor should never fail");
-
-        let user_agent = headers
-            .get("user-agent")
-            .and_then(|hv| hv.to_str().ok())
-            .map(|s| s.to_string());
-
-        Ok(UserAgent(user_agent))
     }
 }
 
@@ -198,28 +175,5 @@ mod tests {
             .unwrap();
         // Should trim whitespace
         assert_eq!(result, "203.0.113.1".parse::<IpAddr>().unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_user_agent_present() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "user-agent",
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
-                .parse()
-                .unwrap(),
-        );
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-
-        let request = make_request(headers, addr);
-        let (mut parts, _) = request.into_parts();
-        let UserAgent(result) = UserAgent::from_request_parts(&mut parts, &())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            result,
-            Some("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36".to_string())
-        );
     }
 }

--- a/src/infrastructure/http/extractors/user_agent.rs
+++ b/src/infrastructure/http/extractors/user_agent.rs
@@ -1,0 +1,62 @@
+use axum::{
+    extract::FromRequestParts,
+    http::{HeaderMap, request::Parts},
+};
+/// Axum extractor for User-Agent header
+///
+/// Extracts the User-Agent header from HTTP requests.
+/// Returns None if the header is missing or cannot be parsed as a valid string.
+pub struct UserAgent(pub Option<String>);
+
+impl<S> FromRequestParts<S> for UserAgent
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let headers = HeaderMap::from_request_parts(parts, state).await?;
+
+        let user_agent = headers
+            .get("user-agent")
+            .and_then(|hv| hv.to_str().ok())
+            .map(|s| s.to_string());
+
+        Ok(UserAgent(user_agent))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{extract::Request, http::HeaderMap};
+
+    // Helper function to create a mock request with headers
+    fn make_request(headers: HeaderMap) -> Request<()> {
+        let mut request = Request::builder().body(()).unwrap();
+        *request.headers_mut() = headers;
+        request
+    }
+
+    #[tokio::test]
+    async fn test_user_agent_present() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "user-agent",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+                .parse()
+                .unwrap(),
+        );
+
+        let request = make_request(headers);
+        let (mut parts, _) = request.into_parts();
+        let UserAgent(result) = UserAgent::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            Some("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36".to_string())
+        );
+    }
+}

--- a/src/infrastructure/http/mod.rs
+++ b/src/infrastructure/http/mod.rs
@@ -3,5 +3,5 @@ pub mod extractors;
 mod server;
 
 pub use error::HttpServerError;
-pub use extractors::RequestOrigin;
+pub use extractors::{RequestOrigin, UserAgent};
 pub use server::HttpServer;

--- a/src/infrastructure/http/mod.rs
+++ b/src/infrastructure/http/mod.rs
@@ -3,5 +3,5 @@ pub mod extractors;
 mod server;
 
 pub use error::HttpServerError;
-pub use extractors::{RequestOrigin, UserAgent};
+pub use extractors::{request_origin::RequestOrigin, user_agent::UserAgent};
 pub use server::HttpServer;

--- a/src/sms_verification/http.rs
+++ b/src/sms_verification/http.rs
@@ -12,7 +12,7 @@ use crate::sms_verification::{
 };
 use crate::{
     EnvConfig,
-    infrastructure::http::{HttpServerError, RequestOrigin},
+    infrastructure::http::{HttpServerError, RequestOrigin, UserAgent},
     sms_verification::app_state::AppState,
 };
 
@@ -42,11 +42,12 @@ pub async fn router_with_db(
 async fn send_code_handler(
     State(mut state): State<AppState>,
     RequestOrigin(ip_address): RequestOrigin,
+    UserAgent(user_agent): UserAgent,
     Json(request): Json<CreateVerificationRequest>,
 ) -> Result<StatusCode, SmsVerificationError> {
     state
         .sms_verification
-        .create_verification(&state.db, request, ip_address)
+        .create_verification(&state.db, request, ip_address, user_agent)
         .await?;
     Ok(StatusCode::OK)
 }

--- a/src/sms_verification/prelude_api.rs
+++ b/src/sms_verification/prelude_api.rs
@@ -128,12 +128,16 @@ struct Target {
 #[derive(Serialize)]
 struct Signals {
     ip_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user_agent: Option<String>,
 }
+
 #[derive(Serialize)]
 struct PreludeCreateVerificationRequest {
     target: Target,
+    signals: Signals,
     #[serde(skip_serializing_if = "Option::is_none")]
-    signals: Option<Signals>,
+    dispatch_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -215,16 +219,20 @@ impl PreludeAPI {
     pub async fn create_verification(
         &self,
         phone_number: &PhoneNumber,
-        ip_address: Option<IpAddr>,
+        ip_address: IpAddr,
+        user_agent: Option<String>,
+        dispatch_id: Option<String>,
     ) -> Result<PreludeCreateVerificationResponse, PreludeError> {
         let request_body = PreludeCreateVerificationRequest {
             target: Target {
                 target_type: "phone_number".to_string(),
                 value: phone_number.to_string(),
             },
-            signals: ip_address.map(|ip| Signals {
-                ip_address: ip.to_string(),
-            }),
+            signals: Signals {
+                ip_address: ip_address.to_string(),
+                user_agent,
+            },
+            dispatch_id,
         };
 
         let url = self

--- a/src/sms_verification/service.rs
+++ b/src/sms_verification/service.rs
@@ -82,6 +82,7 @@ impl SmsVerificationService {
         db: &SqlDb,
         request: CreateVerificationRequest,
         ip_address: IpAddr,
+        user_agent: Option<String>,
     ) -> Result<(), SmsVerificationError> {
         let phone_number_hash = self
             .hasher_argon2id
@@ -94,7 +95,12 @@ impl SmsVerificationService {
 
         let prelude_response = self
             .prelude_api
-            .create_verification(&request.phone_number, Some(ip_address))
+            .create_verification(
+                &request.phone_number,
+                ip_address,
+                user_agent,
+                request.dispatch_id,
+            )
             .await?;
 
         let id = match &prelude_response {

--- a/src/sms_verification/tests.rs
+++ b/src/sms_verification/tests.rs
@@ -49,15 +49,41 @@ async fn create_service_with_mocked_apis(servers: &WiremockServers) -> SmsVerifi
 
 #[sqlx::test]
 async fn test_service_full_verification_flow(pool: PgPool) {
+    use serde_json::json;
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
     let servers = WiremockServers::start().await;
     let mut service = create_service_with_mocked_apis(&servers).await;
     let db = SqlDb::test(pool.clone()).await;
 
     let phone = PhoneNumber::new("+30123456789").unwrap();
     let ip: IpAddr = "127.0.0.1".parse().unwrap();
+    let user_agent = Some("Mozilla/5.0 (Test Client)".to_string());
+    let dispatch_id = Some("test-dispatch-id-123".to_string());
 
-    // Setup wiremock expectations
-    setup_prelude_create_verification(&phone, Some(ip), "success", None)
+    // Setup wiremock expectations - verify exact request body with signals
+    let expected_body = json!({
+        "target": {
+            "type": "phone_number",
+            "value": phone.as_str()
+        },
+        "signals": {
+            "ip_address": ip.to_string(),
+            "user_agent": user_agent.clone().unwrap()
+        },
+        "dispatch_id": dispatch_id.clone().unwrap()
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v2/verification"))
+        .and(header("Authorization", "Bearer test-key"))
+        .and(header("Content-Type", "application/json"))
+        .and(body_json(&expected_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "verification-id-123",
+            "status": "success"
+        })))
         .expect(1)
         .mount(&servers.prelude_server)
         .await;
@@ -72,14 +98,16 @@ async fn test_service_full_verification_flow(pool: PgPool) {
         .mount(&servers.homeserver_server)
         .await;
 
-    // Step 1: Initiate verification
+    // Step 1: Initiate verification with user_agent and dispatch_id
     service
         .create_verification(
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: dispatch_id.clone(),
             },
             ip,
+            user_agent.clone(),
         )
         .await
         .expect("verify_init should succeed");
@@ -189,8 +217,10 @@ async fn test_service_session_lifecycle(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone1.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("First send_code should succeed");
@@ -211,8 +241,10 @@ async fn test_service_session_lifecycle(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone1.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("Second send_code should succeed");
@@ -251,8 +283,10 @@ async fn test_service_session_lifecycle(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone2.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("send_code should succeed");
@@ -275,8 +309,10 @@ async fn test_service_session_lifecycle(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone2.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("send_code after verification should succeed");
@@ -325,8 +361,10 @@ async fn test_service_max_verified_sessions_limits(pool: PgPool) {
                 &db,
                 CreateVerificationRequest {
                     phone_number: phone.clone(),
+                    dispatch_id: None,
                 },
                 ip,
+                None,
             )
             .await
             .unwrap_or_else(|_| panic!("send_code {} should succeed", i));
@@ -349,8 +387,10 @@ async fn test_service_max_verified_sessions_limits(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await;
 
@@ -386,8 +426,10 @@ async fn test_service_max_verified_sessions_limits(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("3rd send_code should succeed after aging");
@@ -434,8 +476,10 @@ async fn test_service_max_verified_sessions_limits(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("4th send_code should succeed");
@@ -478,8 +522,10 @@ async fn test_service_max_verified_sessions_limits(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await;
 
@@ -515,8 +561,10 @@ async fn test_service_input_validation_and_errors(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone_wrong_code.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("send_code should succeed");
@@ -571,8 +619,10 @@ async fn test_service_expired_or_not_found_marks_failed(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("send_code should succeed");
@@ -649,8 +699,10 @@ async fn test_service_expired_or_not_found_marks_failed(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("Should be able to create new session after failure");
@@ -694,8 +746,10 @@ async fn test_service_success_but_homeserver_fails_marks_failed(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("create_verification should succeed");
@@ -764,8 +818,10 @@ async fn test_service_expired_or_not_found_with_mismatched_prelude_id(pool: PgPo
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("create_verification should succeed");
@@ -904,8 +960,10 @@ async fn test_service_verify_code_with_wrong_phone_number(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone_send.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("send_code should succeed");
@@ -961,8 +1019,10 @@ async fn test_service_database_error_handling(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("send_code should succeed");
@@ -1034,8 +1094,10 @@ async fn test_service_verify_code_on_terminal_states(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone_verified.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("create_verification should succeed");
@@ -1109,8 +1171,10 @@ async fn test_service_verify_code_on_terminal_states(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone_failed.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("create_verification should succeed");
@@ -1208,8 +1272,10 @@ async fn test_service_multiple_wrong_code_attempts(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("create_verification should succeed");
@@ -1364,8 +1430,10 @@ async fn test_service_blocked_phone_number(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await;
 
@@ -1456,8 +1524,10 @@ async fn test_service_retry_response_from_prelude(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("create_verification should succeed");
@@ -1522,8 +1592,10 @@ async fn test_repository_state_mutation_protection(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone1.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("create_verification should succeed");
@@ -1624,8 +1696,10 @@ async fn test_repository_state_mutation_protection(pool: PgPool) {
             &db,
             CreateVerificationRequest {
                 phone_number: phone2.clone(),
+                dispatch_id: None,
             },
             ip,
+            None,
         )
         .await
         .expect("create_verification should succeed");

--- a/src/sms_verification/types.rs
+++ b/src/sms_verification/types.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct CreateVerificationRequest {
     pub phone_number: PhoneNumber,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dispatch_id: Option<String>,
 }
 
 /// Request to validate a verification code


### PR DESCRIPTION
Prelude's fraud prevention system's effectiveness increases with the amount of client data it is given. 

Here we send user-agent alongside IP address from the Http requests. See - https://docs.prelude.so/verify/v2/documentation/prevent-fraud#signals

And Allow for a `dispatch_id` to be sent along with a create verification session request. This is used to correlate create verification session requests with client data which the Prelude SDK has already sent to Prelude's API. See - https://docs.prelude.so/introduction/frontend-sdks/web. 