### PR TITLE
Ln verification do not use payment_hash as verification identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,7 @@ dependencies = [
  "chrono",
  "inherent",
  "sea-query-derive",
+ "uuid",
 ]
 
 [[package]]
@@ -2079,6 +2080,7 @@ dependencies = [
  "chrono",
  "sea-query",
  "sqlx",
+ "uuid",
 ]
 
 [[package]]
@@ -2331,6 +2333,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
  "webpki-roots 0.26.11",
 ]
 
@@ -2412,6 +2415,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2450,6 +2454,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2476,6 +2481,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2982,6 +2988,7 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ hex = "0.4"
 regex = "1.11"
 reqwest = { version = "0.12", features = ["json"] }
 reqwest-websocket = "0.5.1"
-sea-query = { version = "0.32.6", features = [ "with-chrono", "postgres-array" ]}
-sea-query-binder = { version = "0.7.0", features = [ "with-chrono", "runtime-tokio", "sqlx-postgres", "postgres-array" ] }
+sea-query = { version = "0.32.6", features = [ "with-chrono", "postgres-array", "with-uuid" ]}
+sea-query-binder = { version = "0.7.0", features = [ "with-chrono", "runtime-tokio", "sqlx-postgres", "postgres-array", "with-uuid" ] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.8.6", features = [ "runtime-tokio", "postgres", "chrono", "tls-rustls" ] }
+sqlx = { version = "0.8.6", features = [ "runtime-tokio", "postgres", "chrono", "tls-rustls", "uuid" ] }
 thiserror = "2.0.12"
 tokio = { version = "1.48.0", features = ["full"] }
 tower-http = { version = "0.6.2", features = ["cors", "trace"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 url = "2.5.7"
-uuid = { version = "1.18.1", features = ["v4"] }
+uuid = { version = "1.18.1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 axum-test = "18"

--- a/src/infrastructure/sql/migrations/m20251216_create_ln_verification.rs
+++ b/src/infrastructure/sql/migrations/m20251216_create_ln_verification.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
-use sea_query::{ColumnDef, PostgresQueryBuilder, Table};
+use sea_query::{ColumnDef, Index, PostgresQueryBuilder, Table};
 use sqlx::Transaction;
 
 use crate::infrastructure::sql::MigrationTrait;
@@ -14,10 +14,17 @@ impl MigrationTrait for M20251216CreateLnVerification {
             .table("lightning_verifications")
             .if_not_exists()
             .col(
+                ColumnDef::new("id")
+                    .uuid()
+                    .not_null()
+                    .primary_key()
+                    .default(sea_query::Expr::cust("gen_random_uuid()")),
+            )
+            .col(
                 ColumnDef::new("payment_hash")
                     .char_len(64)
                     .not_null()
-                    .primary_key(),
+                    .unique_key(),
             ) // 64 hex characters
             .col(ColumnDef::new("amount_sat").integer().not_null())
             .col(ColumnDef::new("signup_code").text().null())
@@ -37,6 +44,15 @@ impl MigrationTrait for M20251216CreateLnVerification {
             .to_owned();
 
         let query = statement.build(PostgresQueryBuilder);
+        sqlx::query(&query).execute(&mut **tx).await?;
+
+        let index = Index::create()
+            .name("idx_lightning_verifications_payment_hash")
+            .table("lightning_verifications")
+            .col("payment_hash")
+            .to_owned();
+
+        let query = index.build(PostgresQueryBuilder);
         sqlx::query(&query).execute(&mut **tx).await?;
 
         Ok(())

--- a/src/infrastructure/sql/migrations/m20251216_create_ln_verification.rs
+++ b/src/infrastructure/sql/migrations/m20251216_create_ln_verification.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
-use sea_query::{ColumnDef, Index, PostgresQueryBuilder, Table};
+use sea_query::{ColumnDef, PostgresQueryBuilder, Table};
 use sqlx::Transaction;
 
 use crate::infrastructure::sql::MigrationTrait;
@@ -44,15 +44,6 @@ impl MigrationTrait for M20251216CreateLnVerification {
             .to_owned();
 
         let query = statement.build(PostgresQueryBuilder);
-        sqlx::query(&query).execute(&mut **tx).await?;
-
-        let index = Index::create()
-            .name("idx_lightning_verifications_payment_hash")
-            .table("lightning_verifications")
-            .col("payment_hash")
-            .to_owned();
-
-        let query = index.build(PostgresQueryBuilder);
         sqlx::query(&query).execute(&mut **tx).await?;
 
         Ok(())

--- a/src/ln_verification/http.rs
+++ b/src/ln_verification/http.rs
@@ -13,9 +13,9 @@ use crate::{
     EnvConfig,
     infrastructure::http::HttpServerError,
     ln_verification::{
-        app_state::AppState, error::LnVerificationError,
-        invoice_background_syncer::InvoiceBackgroundSyncer, payment_hash::PaymentHash,
-        phoenixd_api::PhoenixdAPI, service::LnVerificationService,
+        VerificationId, app_state::AppState, error::LnVerificationError,
+        invoice_background_syncer::InvoiceBackgroundSyncer, phoenixd_api::PhoenixdAPI,
+        service::LnVerificationService,
     },
     shared::HomeserverAdminAPI,
 };
@@ -61,9 +61,9 @@ async fn create_verification_handler(
     State(state): State<AppState>,
 ) -> Result<Json<CreateVerificationResponse>, LnVerificationError> {
     let (verification, invoice) = state.ln_service.create_verification().await?;
-    tracing::info!("Created verification {}", verification.payment_hash);
+    tracing::info!("Created verification {}", verification.id);
     let response = CreateVerificationResponse {
-        id: verification.payment_hash,
+        id: verification.id,
         bolt11_invoice: invoice.invoice,
         amount_sat: invoice.requested_sat,
         expires_at: invoice.expires_at.timestamp_millis(),
@@ -74,7 +74,7 @@ async fn create_verification_handler(
 /// Get a Lightning Network verification handler
 async fn get_verification_handler(
     State(state): State<AppState>,
-    Path(id): Path<PaymentHash>,
+    Path(id): Path<VerificationId>,
 ) -> Response {
     let verification = match state.ln_service.get_verification(&id).await {
         Ok(Some(verification)) => verification,
@@ -91,7 +91,7 @@ async fn get_verification_handler(
 /// Await for a Lightning Network verification to be finalized handler
 async fn await_verification_handler(
     State(state): State<AppState>,
-    Path(id): Path<PaymentHash>,
+    Path(id): Path<VerificationId>,
 ) -> impl IntoResponse {
     let mut verification = match state.ln_service.get_verification(&id).await {
         Ok(Some(verification)) => verification,
@@ -115,7 +115,7 @@ async fn await_verification_handler(
             }
             Err(e) => return e.into_response(),
         };
-        tracing::info!("Awaited verification {}", verification.payment_hash);
+        tracing::info!("Awaited verification {}", verification.id);
     };
 
     Json(GetVerificationResponse::from_entity(
@@ -128,7 +128,7 @@ async fn await_verification_handler(
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateVerificationResponse {
-    id: PaymentHash,
+    id: VerificationId,
     bolt11_invoice: String,
     amount_sat: u64,
     expires_at: i64,
@@ -137,7 +137,7 @@ pub struct CreateVerificationResponse {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetVerificationResponse {
-    id: PaymentHash,
+    id: VerificationId,
     amount_sat: u64,
     expires_at: i64,
     is_paid: bool,
@@ -153,7 +153,7 @@ impl GetVerificationResponse {
     ) -> Self {
         let is_paid = entity.is_finalised();
         Self {
-            id: entity.payment_hash,
+            id: entity.id,
             amount_sat: entity.amount_sat as u64,
             expires_at: entity.expires_at.and_utc().timestamp_millis(),
             is_paid,

--- a/src/ln_verification/http.rs
+++ b/src/ln_verification/http.rs
@@ -53,6 +53,7 @@ pub async fn router(
         .route("/", post(create_verification_handler))
         .route("/{id}", get(get_verification_handler))
         .route("/{id}/await", get(await_verification_handler))
+        .route("/price", get(get_price_handler))
         .with_state(state))
 }
 
@@ -125,6 +126,13 @@ async fn await_verification_handler(
     .into_response()
 }
 
+/// Get the configured Lightning invoice price handler
+async fn get_price_handler(State(state): State<AppState>) -> Json<GetPriceResponse> {
+    Json(GetPriceResponse {
+        amount_sat: state.ln_service.get_price_sat(),
+    })
+}
+
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateVerificationResponse {
@@ -162,6 +170,12 @@ impl GetVerificationResponse {
             created_at: entity.created_at.and_utc().timestamp_millis(),
         }
     }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetPriceResponse {
+    amount_sat: u64,
 }
 
 impl IntoResponse for LnVerificationError {

--- a/src/ln_verification/invoice_background_syncer.rs
+++ b/src/ln_verification/invoice_background_syncer.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use crate::ln_verification::{
-    LightningVerificationEntity, error::LnVerificationError, payment_hash::PaymentHash,
-    phoenixd_api::PhoenixdAPI, service::LnVerificationService,
+    LightningVerificationEntity, VerificationId, error::LnVerificationError,
+    payment_hash::PaymentHash, phoenixd_api::PhoenixdAPI, service::LnVerificationService,
 };
 
 use futures_util::TryStreamExt;
@@ -13,7 +13,7 @@ use tokio::sync::broadcast;
 pub struct InvoiceBackgroundSyncer {
     service: LnVerificationService,
     phoenixd_api: PhoenixdAPI,
-    verification_completed_tx: broadcast::Sender<PaymentHash>,
+    verification_completed_tx: broadcast::Sender<VerificationId>,
 }
 
 impl InvoiceBackgroundSyncer {
@@ -29,7 +29,7 @@ impl InvoiceBackgroundSyncer {
 
     /// Subscribe to finalized verification events.
     /// Returns a receiver that will receive notifications whenever a verification is finalized.
-    pub fn subscribe(&self) -> broadcast::Receiver<PaymentHash> {
+    pub fn subscribe(&self) -> broadcast::Receiver<VerificationId> {
         self.verification_completed_tx.subscribe()
     }
 
@@ -37,15 +37,15 @@ impl InvoiceBackgroundSyncer {
     /// Returns Ok(Some(LightningVerificationEntity)) if the payment was finalized, Ok(None) if the timeout was reached.
     pub async fn wait_for_payment(
         &self,
-        payment_hash: &PaymentHash,
+        id: &VerificationId,
         timeout: Duration,
     ) -> Result<Option<LightningVerificationEntity>, LnVerificationError> {
         let future = async {
             let mut receiver = self.subscribe();
             loop {
                 match receiver.recv().await {
-                    Ok(finalized_payment_hash) if finalized_payment_hash == *payment_hash => break,
-                    Ok(_) => continue, // Different payment hash, keep waiting
+                    Ok(finalized_id) if finalized_id == *id => break,
+                    Ok(_) => continue, // Different verification ID, keep waiting
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         tracing::warn!("Broadcast receiver lagged by {} messages", n);
                         continue;
@@ -63,7 +63,7 @@ impl InvoiceBackgroundSyncer {
             Err(_) => return Ok(None),
         };
 
-        self.service.get_verification(payment_hash).await
+        self.service.get_verification(id).await
     }
 
     /// Sync an invoice.
@@ -75,10 +75,8 @@ impl InvoiceBackgroundSyncer {
             Some(verification) => verification,
             None => return Ok(()),
         };
-        tracing::info!("Verification {} finalised", newly_finalised.payment_hash);
-        let _ = self
-            .verification_completed_tx
-            .send(newly_finalised.payment_hash);
+        tracing::info!("Verification {} finalised", newly_finalised.id);
+        let _ = self.verification_completed_tx.send(newly_finalised.id);
         Ok(())
     }
 

--- a/src/ln_verification/mod.rs
+++ b/src/ln_verification/mod.rs
@@ -6,5 +6,7 @@ mod payment_hash;
 mod phoenixd_api;
 mod repository;
 mod service;
+mod verification_id;
 pub use http::router;
 pub use repository::*;
+pub use verification_id::*;

--- a/src/ln_verification/repository.rs
+++ b/src/ln_verification/repository.rs
@@ -9,7 +9,8 @@ use sea_query_binder::SqlxBinder;
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct LightningVerificationEntity {
     pub id: VerificationId,
-    #[allow(dead_code)] // Stored for data integrity and testing. Sync operations use payment_hash from phoenixd API responses
+    #[allow(dead_code)]
+    // Stored for data integrity and testing. Sync operations use payment_hash from phoenixd API responses
     pub payment_hash: PaymentHash,
     pub amount_sat: i32,
     pub expires_at: NaiveDateTime,

--- a/src/ln_verification/repository.rs
+++ b/src/ln_verification/repository.rs
@@ -1,10 +1,15 @@
-use crate::{infrastructure::sql::UnifiedExecutor, ln_verification::payment_hash::PaymentHash};
+use crate::{
+    infrastructure::sql::UnifiedExecutor,
+    ln_verification::{payment_hash::PaymentHash, verification_id::VerificationId},
+};
 use chrono::NaiveDateTime;
 use sea_query::{Expr, PostgresQueryBuilder, Query};
 use sea_query_binder::SqlxBinder;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct LightningVerificationEntity {
+    pub id: VerificationId,
+    #[allow(dead_code)] // Used for internal Phoenix sync operations
     pub payment_hash: PaymentHash,
     pub amount_sat: i32,
     pub expires_at: NaiveDateTime,
@@ -65,6 +70,46 @@ impl LnVerificationRepository {
         Ok(verification)
     }
 
+    /// Get a verification by its public ID (for API requests)
+    ///
+    /// # Arguments
+    /// * `id` - The verification ID
+    /// * `executor` - The executor to use to execute the query
+    ///
+    /// # Returns
+    /// * `LightningVerificationEntity` - The verification record
+    ///
+    /// # Errors
+    /// * `sqlx::Error` - If the query fails
+    pub async fn get_verification_by_id<'a>(
+        id: &VerificationId,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<Option<LightningVerificationEntity>, sqlx::Error> {
+        let statement = Query::select()
+            .columns([
+                "id",
+                "payment_hash",
+                "amount_sat",
+                "created_at",
+                "expires_at",
+                "finalised_at",
+                "signup_code",
+            ])
+            .from(TABLE_NAME)
+            .and_where(Expr::col("id").eq(*id.as_uuid()))
+            .to_owned();
+        let (query, values) = statement.build_sqlx(PostgresQueryBuilder);
+        let con = executor.get_con().await?;
+        let verification: LightningVerificationEntity =
+            match sqlx::query_as_with(&query, values).fetch_one(con).await {
+                Ok(verification) => verification,
+                Err(sqlx::Error::RowNotFound) => return Ok(None),
+                Err(e) => return Err(e),
+            };
+
+        Ok(Some(verification))
+    }
+
     /// Get a verification by payment hash
     ///
     /// # Arguments
@@ -82,6 +127,7 @@ impl LnVerificationRepository {
     ) -> Result<Option<LightningVerificationEntity>, sqlx::Error> {
         let statement = Query::select()
             .columns([
+                "id",
                 "payment_hash",
                 "amount_sat",
                 "created_at",
@@ -315,5 +361,40 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(timestamp, Some(veri1.created_at));
+    }
+
+    #[sqlx::test]
+    async fn test_get_verification_by_id(pool: PgPool) {
+        let db = SqlDb::test(pool).await;
+        let payment_hash = PaymentHash::random();
+        let expires_at = Utc::now().naive_utc();
+        let veri = LnVerificationRepository::create_verification(
+            &payment_hash,
+            1000,
+            expires_at,
+            &mut db.pool().into(),
+        )
+        .await
+        .unwrap();
+
+        // Should be able to get by ID
+        let veri_by_id =
+            LnVerificationRepository::get_verification_by_id(&veri.id, &mut db.pool().into())
+                .await
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(veri_by_id.id, veri.id);
+        assert_eq!(veri_by_id.payment_hash, payment_hash);
+        assert_eq!(veri_by_id.amount_sat, 1000);
+
+        // Non-existent ID should return None
+        let non_existent = LnVerificationRepository::get_verification_by_id(
+            &VerificationId::random(),
+            &mut db.pool().into(),
+        )
+        .await
+        .unwrap();
+        assert!(non_existent.is_none());
     }
 }

--- a/src/ln_verification/repository.rs
+++ b/src/ln_verification/repository.rs
@@ -9,7 +9,7 @@ use sea_query_binder::SqlxBinder;
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct LightningVerificationEntity {
     pub id: VerificationId,
-    #[allow(dead_code)] // Used for internal Phoenix sync operations
+    #[allow(dead_code)] // Stored for data integrity and testing. Sync operations use payment_hash from phoenixd API responses
     pub payment_hash: PaymentHash,
     pub amount_sat: i32,
     pub expires_at: NaiveDateTime,

--- a/src/ln_verification/service.rs
+++ b/src/ln_verification/service.rs
@@ -5,8 +5,8 @@ use chrono::{NaiveDateTime, TimeDelta};
 use crate::{
     infrastructure::sql::{SqlDb, UnifiedExecutor},
     ln_verification::{
-        LightningVerificationEntity, LnVerificationRepository, error::LnVerificationError,
-        payment_hash::PaymentHash, phoenixd_api::PhoenixdAPI,
+        LightningVerificationEntity, LnVerificationRepository, VerificationId,
+        error::LnVerificationError, payment_hash::PaymentHash, phoenixd_api::PhoenixdAPI,
     },
     shared::HomeserverAdminAPI,
 };
@@ -138,19 +138,17 @@ impl LnVerificationService {
         Ok(timestamp)
     }
 
-    /// Get a verification by its payment hash.
+    /// Get a verification by its verification ID.
     /// Returns the verification if it exists, None if it does not exist.
     /// # Errors
     /// * `LnVerificationError` - If the verification retrieval fails
     pub async fn get_verification(
         &self,
-        payment_hash: &PaymentHash,
+        id: &VerificationId,
     ) -> Result<Option<LightningVerificationEntity>, LnVerificationError> {
-        let verification = LnVerificationRepository::get_verification_by_payment_hash(
-            payment_hash,
-            &mut self.db.pool().into(),
-        )
-        .await?;
+        let verification =
+            LnVerificationRepository::get_verification_by_id(id, &mut self.db.pool().into())
+                .await?;
         Ok(verification)
     }
 }

--- a/src/ln_verification/service.rs
+++ b/src/ln_verification/service.rs
@@ -151,4 +151,9 @@ impl LnVerificationService {
                 .await?;
         Ok(verification)
     }
+
+    /// Get the configured price for Lightning invoices in satoshis.
+    pub fn get_price_sat(&self) -> u64 {
+        self.amount_sat
+    }
 }

--- a/src/ln_verification/verification_id.rs
+++ b/src/ln_verification/verification_id.rs
@@ -71,3 +71,196 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for VerificationId {
         Ok(Self(uuid))
     }
 }
+
+impl<'q> sqlx::Encode<'q, sqlx::Postgres> for VerificationId {
+    fn encode_by_ref(
+        &self,
+        buf: &mut sqlx::postgres::PgArgumentBuffer,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        <&Uuid as sqlx::Encode<sqlx::Postgres>>::encode_by_ref(&&self.0, buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_uuid() {
+        let valid_uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let verification_id = VerificationId::from_str(valid_uuid).unwrap();
+        assert_eq!(verification_id.to_string(), valid_uuid);
+    }
+
+    #[test]
+    fn test_valid_uuid_uppercase() {
+        let uppercase_uuid = "550E8400-E29B-41D4-A716-446655440000";
+        let verification_id = VerificationId::from_str(uppercase_uuid).unwrap();
+        // UUIDs are normalized to lowercase
+        assert_eq!(
+            verification_id.to_string(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+
+    #[test]
+    fn test_invalid_format_not_uuid() {
+        let invalid = "not-a-uuid";
+        let result = VerificationId::from_str(invalid);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            VerificationIdError::InvalidFormat(_) => {}
+        }
+    }
+
+    #[test]
+    fn test_invalid_format_empty() {
+        let empty = "";
+        let result = VerificationId::from_str(empty);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_format_wrong_length() {
+        let wrong_length = "550e8400-e29b-41d4-a716";
+        let result = VerificationId::from_str(wrong_length);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_format_invalid_hex() {
+        // UUID parser actually accepts UUIDs without hyphens, so test invalid hex instead
+        let invalid_hex = "550e8400-e29b-41d4-a716-44665544000g";
+        let result = VerificationId::from_str(invalid_hex);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_display_trait() {
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let verification_id = VerificationId::from_str(uuid_str).unwrap();
+        assert_eq!(format!("{}", verification_id), uuid_str);
+    }
+
+    #[test]
+    fn test_from_str_valid() {
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let verification_id: VerificationId = uuid_str.parse().unwrap();
+        assert_eq!(verification_id.to_string(), uuid_str);
+    }
+
+    #[test]
+    fn test_from_str_invalid() {
+        let invalid = "invalid-uuid-format";
+        let result: Result<VerificationId, _> = invalid.parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_serialize() {
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let verification_id = VerificationId::from_str(uuid_str).unwrap();
+        let serialized = serde_json::to_string(&verification_id).unwrap();
+        assert_eq!(serialized, format!("\"{}\"", uuid_str));
+    }
+
+    #[test]
+    fn test_deserialize_valid() {
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let json = format!("\"{}\"", uuid_str);
+        let verification_id: VerificationId = serde_json::from_str(&json).unwrap();
+        assert_eq!(verification_id.to_string(), uuid_str);
+    }
+
+    #[test]
+    fn test_deserialize_invalid_format() {
+        let json = "\"not-a-uuid\"";
+        let result: Result<VerificationId, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_invalid_json() {
+        let json = "not-json";
+        let result: Result<VerificationId, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let id1 = VerificationId::from_str(uuid_str).unwrap();
+        let id2 = VerificationId::from_str(uuid_str).unwrap();
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_partial_eq_different() {
+        let id1 = VerificationId::from_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let id2 = VerificationId::from_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_clone() {
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let id = VerificationId::from_str(uuid_str).unwrap();
+        let cloned = id.clone();
+        assert_eq!(id, cloned);
+    }
+
+    #[test]
+    fn test_hash_trait() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let id1 = VerificationId::from_str(uuid_str).unwrap();
+        let id2 = VerificationId::from_str(uuid_str).unwrap();
+
+        let mut hasher1 = DefaultHasher::new();
+        id1.hash(&mut hasher1);
+        let hash_value1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        id2.hash(&mut hasher2);
+        let hash_value2 = hasher2.finish();
+
+        assert_eq!(hash_value1, hash_value2);
+    }
+
+    #[test]
+    fn test_as_uuid() {
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let verification_id = VerificationId::from_str(uuid_str).unwrap();
+        let uuid = verification_id.as_uuid();
+        assert_eq!(uuid.to_string(), uuid_str);
+    }
+
+    #[test]
+    fn test_random_generates_valid_uuid() {
+        let id1 = VerificationId::random();
+        let id2 = VerificationId::random();
+
+        // Should generate different UUIDs
+        assert_ne!(id1, id2);
+
+        // Should be valid UUID format
+        assert!(Uuid::parse_str(&id1.to_string()).is_ok());
+        assert!(Uuid::parse_str(&id2.to_string()).is_ok());
+    }
+
+    #[test]
+    fn test_error_display() {
+        let error = VerificationIdError::InvalidFormat("test error".to_string());
+        assert_eq!(error.to_string(), "Invalid verification ID format: test error");
+    }
+
+    #[test]
+    fn test_debug_trait() {
+        let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
+        let verification_id = VerificationId::from_str(uuid_str).unwrap();
+        let debug_str = format!("{:?}", verification_id);
+        assert!(debug_str.contains("VerificationId"));
+    }
+}

--- a/src/ln_verification/verification_id.rs
+++ b/src/ln_verification/verification_id.rs
@@ -1,0 +1,73 @@
+use std::{fmt::Display, str::FromStr};
+
+use uuid::Uuid;
+
+/// Error type for verification ID parse operations
+#[derive(thiserror::Error, Debug)]
+pub enum VerificationIdError {
+    #[error("Invalid verification ID format: {0}")]
+    InvalidFormat(String),
+}
+
+/// Verification ID for Lightning Network verifications.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VerificationId(Uuid);
+
+impl VerificationId {
+    #[cfg(test)]
+    pub fn random() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    pub fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl Display for VerificationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for VerificationId {
+    type Err = VerificationIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uuid =
+            Uuid::parse_str(s).map_err(|e| VerificationIdError::InvalidFormat(e.to_string()))?;
+        Ok(Self(uuid))
+    }
+}
+
+impl serde::Serialize for VerificationId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for VerificationId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for VerificationId {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name("uuid")
+    }
+}
+
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for VerificationId {
+    fn decode(value: sqlx::postgres::PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
+        let uuid = <Uuid as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
+        Ok(Self(uuid))
+    }
+}

--- a/src/ln_verification/verification_id.rs
+++ b/src/ln_verification/verification_id.rs
@@ -253,7 +253,10 @@ mod tests {
     #[test]
     fn test_error_display() {
         let error = VerificationIdError::InvalidFormat("test error".to_string());
-        assert_eq!(error.to_string(), "Invalid verification ID format: test error");
+        assert_eq!(
+            error.to_string(),
+            "Invalid verification ID format: test error"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Create a new `Id` uuid on ln verifications instead of using payment_hash.

Also adds `ln_verificaiton/price` endpoint to fetch configured invoice price.

## Breaking change

This db schema change is breaking in Staging. (Production is not yet deployed)
I'll manually drop the tables before depploying:
```
DROP TABLE IF EXISTS lightning_verifications;
DELETE FROM migrations WHERE name = 'm20251216_create_ln_verification';
```