### PR TITLE
chore: decreased long poll timeout from 60s to 25s + race condition fix

### DIFF
--- a/src/ln_verification/http.rs
+++ b/src/ln_verification/http.rs
@@ -19,12 +19,11 @@ use crate::{
     shared::HomeserverAdminAPI,
 };
 
-
 /// Default timeout for long-polling verification requests
 /// Set to 25 seconds to be below common reverse proxy timeouts (30 seconds)
 /// This way, you don't have to deal with proxy timeouts like nginx cutting the connection
 /// before the application can respond with a timeout message.
-const DEFAULT_TIMEOUT_SECS: u64 = 25;  
+const DEFAULT_TIMEOUT_SECS: u64 = 25;
 
 pub async fn router(
     config: &EnvConfig,
@@ -106,7 +105,6 @@ async fn await_verification_handler(
     State(state): State<AppState>,
     Path(id): Path<VerificationId>,
 ) -> impl IntoResponse {
- 
     let response = match state
         .ln_service
         .get_and_await_verification(&id, Duration::from_secs(DEFAULT_TIMEOUT_SECS))

--- a/src/ln_verification/http.rs
+++ b/src/ln_verification/http.rs
@@ -19,6 +19,13 @@ use crate::{
     shared::HomeserverAdminAPI,
 };
 
+
+/// Default timeout for long-polling verification requests
+/// Set to 25 seconds to be below common reverse proxy timeouts (30 seconds)
+/// This way, you don't have to deal with proxy timeouts like nginx cutting the connection
+/// before the application can respond with a timeout message.
+const DEFAULT_TIMEOUT_SECS: u64 = 25;  
+
 pub async fn router(
     config: &EnvConfig,
     db: &crate::infrastructure::sql::SqlDb,
@@ -99,9 +106,10 @@ async fn await_verification_handler(
     State(state): State<AppState>,
     Path(id): Path<VerificationId>,
 ) -> impl IntoResponse {
+ 
     let response = match state
         .ln_service
-        .get_and_await_verification(&id, Duration::from_secs(60))
+        .get_and_await_verification(&id, Duration::from_secs(DEFAULT_TIMEOUT_SECS))
         .await
     {
         Ok(Some(response)) => response,

--- a/src/ln_verification/service.rs
+++ b/src/ln_verification/service.rs
@@ -135,7 +135,13 @@ impl LnVerificationService {
         tx.commit().await?;
 
         tracing::info!("Verification {} finalised", verification.id);
-        let _ = self.completion_tx.send(verification.id.clone());
+        if let Err(e) = self.completion_tx.send(verification.id.clone()) {
+            tracing::warn!(
+                "Failed to broadcast verification completion for {}: {}",
+                verification.id,
+                e
+            );
+        }
 
         Ok(Some(verification))
     }
@@ -202,8 +208,9 @@ impl LnVerificationService {
     }
 
     /// Get a verification and wait for it to finalize if needed.
-    /// - First gets and syncs the verification
-    /// - If not finalized, waits up to `timeout` for payment
+    /// - Subscribes to broadcast channel FIRST to avoid race condition
+    /// - Then gets and syncs the verification
+    /// - If not finalized, waits up to `timeout` for payment using pre-subscribed receiver
     ///
     /// # Returns
     /// * `Ok(Some(VerificationResponse::Success))` - Verification finalized (already or within timeout)
@@ -215,21 +222,21 @@ impl LnVerificationService {
         id: &VerificationId,
         timeout: Duration,
     ) -> Result<Option<VerificationResponse>, LnVerificationError> {
-        let mut verification = match self.get_and_sync_verification(id).await? {
+        let receiver = self.subscribe();
+
+        let verification = match self.get_and_sync_verification(id).await? {
             Some(v) => v,
             None => return Ok(None),
         };
 
-        if !verification.is_finalised() {
-            match self.wait_for_payment(id, timeout).await? {
-                Some(v) => {
-                    verification = v;
-                    Ok(Some(VerificationResponse::Success(verification)))
-                }
-                None => Ok(Some(VerificationResponse::TimedOut)),
-            }
-        } else {
-            Ok(Some(VerificationResponse::Success(verification)))
+        if verification.is_finalised() {
+            // Already finalized
+            return Ok(Some(VerificationResponse::Success(verification)));
+        }
+
+        match self.wait_for_payment_with_receiver(id, timeout, receiver).await? {
+            Some(v) => Ok(Some(VerificationResponse::Success(v))),
+            None => Ok(Some(VerificationResponse::TimedOut)),
         }
     }
 
@@ -239,21 +246,27 @@ impl LnVerificationService {
         self.completion_tx.subscribe()
     }
 
-    /// Wait for a verification to be finalized, with timeout.
+    /// Wait for a verification to be finalized using a pre-subscribed receiver.
     /// Returns Ok(Some(verification)) if finalized within timeout, Ok(None) if timeout exceeded.
-    async fn wait_for_payment(
+    async fn wait_for_payment_with_receiver(
         &self,
         id: &VerificationId,
         timeout: Duration,
+        mut receiver: broadcast::Receiver<VerificationId>,
     ) -> Result<Option<LightningVerificationEntity>, LnVerificationError> {
         let future = async {
-            let mut receiver = self.subscribe();
             loop {
                 match receiver.recv().await {
                     Ok(finalized_id) if finalized_id == *id => break,
                     Ok(_) => continue, // Different verification ID, keep waiting
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         tracing::warn!("Broadcast receiver lagged by {} messages", n);
+                        // Check if our verification was in the missed messages
+                        if let Ok(Some(v)) = self.get_verification(id).await {
+                            if v.is_finalised() {
+                                break;
+                            }
+                        }
                         continue;
                     }
                     Err(broadcast::error::RecvError::Closed) => {

--- a/src/ln_verification/service.rs
+++ b/src/ln_verification/service.rs
@@ -234,7 +234,10 @@ impl LnVerificationService {
             return Ok(Some(VerificationResponse::Success(verification)));
         }
 
-        match self.wait_for_payment_with_receiver(id, timeout, receiver).await? {
+        match self
+            .wait_for_payment_with_receiver(id, timeout, receiver)
+            .await?
+        {
             Some(v) => Ok(Some(VerificationResponse::Success(v))),
             None => Ok(Some(VerificationResponse::TimedOut)),
         }
@@ -262,10 +265,10 @@ impl LnVerificationService {
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         tracing::warn!("Broadcast receiver lagged by {} messages", n);
                         // Check if our verification was in the missed messages
-                        if let Ok(Some(v)) = self.get_verification(id).await {
-                            if v.is_finalised() {
-                                break;
-                            }
+                        if let Ok(Some(v)) = self.get_verification(id).await
+                            && v.is_finalised()
+                        {
+                            break;
                         }
                         continue;
                     }


### PR DESCRIPTION
## Timeout Decrease

So far, ln verification await timeout was 60s. This is higher than a lot of default request timeouts like on nginx for example. The request therefore has a high chance to timeout due to the proxy instead of the actual timeout in homegate.

This PR sets the homegate timeout to 25s which is lower than the default timeout of 30s that most proxies including nginx use. This avoids needing to manually configuring nginx.

This will not impact Franky in any way as Franky just keeps polling as long as it's needed.

## Fix Race Condition 

Also fixes two unlikely but possible race condition.