### PR TITLE
feat: Handle missing Prelude response type

### DIFF
--- a/src/sms_verification/prelude_api.rs
+++ b/src/sms_verification/prelude_api.rs
@@ -149,14 +149,21 @@ pub enum PreludeBlockedReason {
     InBlockList,
     /// The phone number is not a valid line number (e.g. landline).
     InvalidPhoneLine,
+    /// The phone number is not a valid phone number (e.g. unallocated range).
+    InvalidPhoneNumber,
     /// The signature of the SDK signals is invalid.
     InvalidSignature,
     /// The phone number has made too many verification attempts.
     RepeatedAttempts,
     /// The verification attempt was deemed suspicious by the anti-fraud system.
     Suspicious,
-    /// Prelude API returned Blocked status without a reason.
+    /// Prelude API returned a blocked reason we don't recognise.
+    #[serde(other)]
     Unknown,
+}
+
+fn default_blocked_reason() -> PreludeBlockedReason {
+    PreludeBlockedReason::Unknown
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -170,6 +177,7 @@ pub enum PreludeCreateVerificationResponse {
     },
     Blocked {
         id: String,
+        #[serde(default = "default_blocked_reason")]
         reason: PreludeBlockedReason,
     },
 }

--- a/src/sms_verification/prelude_api.rs
+++ b/src/sms_verification/prelude_api.rs
@@ -140,8 +140,7 @@ struct PreludeCreateVerificationRequest {
     dispatch_id: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PreludeBlockedReason {
     /// The signature of the SDK signals is expired. They should be sent within the hour following their collection.
     ExpiredSignature,
@@ -158,12 +157,60 @@ pub enum PreludeBlockedReason {
     /// The verification attempt was deemed suspicious by the anti-fraud system.
     Suspicious,
     /// Prelude API returned a blocked reason we don't recognise.
-    #[serde(other)]
-    Unknown,
+    Unknown(String),
 }
 
-fn default_blocked_reason() -> PreludeBlockedReason {
-    PreludeBlockedReason::Unknown
+impl<'de> serde::Deserialize<'de> for PreludeBlockedReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = Option::<String>::deserialize(deserializer)?;
+        match s.as_deref() {
+            None => Ok(PreludeBlockedReason::Unknown("absent".to_string())),
+            Some("expired_signature") => Ok(PreludeBlockedReason::ExpiredSignature),
+            Some("in_block_list") => Ok(PreludeBlockedReason::InBlockList),
+            Some("invalid_phone_line") => Ok(PreludeBlockedReason::InvalidPhoneLine),
+            Some("invalid_phone_number") => Ok(PreludeBlockedReason::InvalidPhoneNumber),
+            Some("invalid_signature") => Ok(PreludeBlockedReason::InvalidSignature),
+            Some("repeated_attempts") => Ok(PreludeBlockedReason::RepeatedAttempts),
+            Some("suspicious") => Ok(PreludeBlockedReason::Suspicious),
+            Some(other) => Ok(PreludeBlockedReason::Unknown(other.to_string())),
+        }
+    }
+}
+
+impl serde::Serialize for PreludeBlockedReason {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            PreludeBlockedReason::Unknown(raw) => serializer.serialize_str(raw),
+            other => serializer.serialize_str(&other.to_string()),
+        }
+    }
+}
+
+impl Default for PreludeBlockedReason {
+    fn default() -> Self {
+        PreludeBlockedReason::Unknown("absent".to_string())
+    }
+}
+
+impl std::fmt::Display for PreludeBlockedReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PreludeBlockedReason::ExpiredSignature => write!(f, "expired_signature"),
+            PreludeBlockedReason::InBlockList => write!(f, "in_block_list"),
+            PreludeBlockedReason::InvalidPhoneLine => write!(f, "invalid_phone_line"),
+            PreludeBlockedReason::InvalidPhoneNumber => write!(f, "invalid_phone_number"),
+            PreludeBlockedReason::InvalidSignature => write!(f, "invalid_signature"),
+            PreludeBlockedReason::RepeatedAttempts => write!(f, "repeated_attempts"),
+            PreludeBlockedReason::Suspicious => write!(f, "suspicious"),
+            PreludeBlockedReason::Unknown(s) => write!(f, "unknown({})", s),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -177,7 +224,7 @@ pub enum PreludeCreateVerificationResponse {
     },
     Blocked {
         id: String,
-        #[serde(default = "default_blocked_reason")]
+        #[serde(default)]
         reason: PreludeBlockedReason,
     },
 }
@@ -260,6 +307,18 @@ impl PreludeAPI {
 
         let verification_response = response.json::<PreludeCreateVerificationResponse>().await?;
 
+        if let PreludeCreateVerificationResponse::Blocked {
+            reason: PreludeBlockedReason::Unknown(ref raw),
+            ref id,
+        } = verification_response
+        {
+            tracing::warn!(
+                prelude_id = %id,
+                raw_reason = %raw,
+                "Prelude returned unrecognised blocked reason"
+            );
+        }
+
         Ok(verification_response)
     }
 
@@ -294,5 +353,62 @@ impl PreludeAPI {
         let check_response = response.json::<PreludeCheckCodeResponse>().await?;
 
         Ok(check_response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_blocked_with_known_reason() {
+        let json = r#"{"status":"blocked","id":"x","reason":"repeated_attempts"}"#;
+        let resp: PreludeCreateVerificationResponse = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            resp,
+            PreludeCreateVerificationResponse::Blocked {
+                reason: PreludeBlockedReason::RepeatedAttempts,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn deserialize_blocked_with_unknown_reason() {
+        let json = r#"{"status":"blocked","id":"x","reason":"brand_new_reason"}"#;
+        let resp: PreludeCreateVerificationResponse = serde_json::from_str(json).unwrap();
+        match resp {
+            PreludeCreateVerificationResponse::Blocked { reason, .. } => {
+                assert_eq!(
+                    reason,
+                    PreludeBlockedReason::Unknown("brand_new_reason".to_string())
+                );
+            }
+            other => panic!("Expected Blocked variant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn deserialize_blocked_without_reason_field() {
+        let json = r#"{"status":"blocked","id":"x"}"#;
+        let resp: PreludeCreateVerificationResponse = serde_json::from_str(json).unwrap();
+        match resp {
+            PreludeCreateVerificationResponse::Blocked { reason, .. } => {
+                assert_eq!(reason, PreludeBlockedReason::Unknown("absent".to_string()));
+            }
+            other => panic!("Expected Blocked variant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn deserialize_blocked_with_null_reason() {
+        let json = r#"{"status":"blocked","id":"x","reason":null}"#;
+        let resp: PreludeCreateVerificationResponse = serde_json::from_str(json).unwrap();
+        match resp {
+            PreludeCreateVerificationResponse::Blocked { reason, .. } => {
+                assert_eq!(reason, PreludeBlockedReason::Unknown("absent".to_string()));
+            }
+            other => panic!("Expected Blocked variant, got {:?}", other),
+        }
     }
 }

--- a/src/sms_verification/service.rs
+++ b/src/sms_verification/service.rs
@@ -140,12 +140,11 @@ impl SmsVerificationService {
 
         if let PreludeCreateVerificationResponse::Blocked { id, reason } = &prelude_response {
             tracing::info!(
-                "Phone number blocked for reason: {:?}. prelude id: {}",
-                reason,
-                id
+                prelude_id = %id,
+                reason = %reason,
+                "Phone number blocked by Prelude"
             );
-            SmsVerificationRepository::mark_failed(&mut executor, id, &format!("{:?}", reason))
-                .await?;
+            SmsVerificationRepository::mark_failed(&mut executor, id, &reason.to_string()).await?;
 
             return Err(SmsVerificationError::Blocked);
         }

--- a/src/sms_verification/tests.rs
+++ b/src/sms_verification/tests.rs
@@ -1628,7 +1628,7 @@ async fn test_service_blocked_phone_number(pool: PgPool) {
     );
     let failure_reason = failure_reason.unwrap();
     assert!(
-        failure_reason.contains("RepeatedAttempts"),
+        failure_reason.contains("repeated_attempts"),
         "failure_reason should contain the blocked reason, got: {}",
         failure_reason
     );


### PR DESCRIPTION
- Handle Prelude's `Blocked: inavlid_phone_number` variant 
- Also default when blocked reason is unknown

Before:
```
ERROR Failed to communicate with SMS provider error=error decoding response body
→ HTTP 500 Internal Server Error
```

After:
```
INFO Phone number blocked for reason: InvalidPhoneNumber. prelude id: ...
→ HTTP 403 Forbidden — "Phone number blocked for verification"
```
