### PR TITLE
fix: incorrect signals.ip_address field name

### DIFF
--- a/src/e2e/wiremock_helpers.rs
+++ b/src/e2e/wiremock_helpers.rs
@@ -37,7 +37,7 @@ pub fn setup_prelude_create_verification(
 
     if let Some(ip) = ip_address {
         body["signals"] = json!({
-            "ip_address": ip.to_string()
+            "ip": ip.to_string()
         });
     }
 

--- a/src/sms_verification/prelude_api.rs
+++ b/src/sms_verification/prelude_api.rs
@@ -127,7 +127,7 @@ struct Target {
 
 #[derive(Serialize)]
 struct Signals {
-    ip_address: String,
+    ip: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     user_agent: Option<String>,
 }
@@ -284,7 +284,7 @@ impl PreludeAPI {
                 value: phone_number.to_string(),
             },
             signals: Signals {
-                ip_address: ip_address.to_string(),
+                ip: ip_address.to_string(),
                 user_agent,
             },
             dispatch_id,

--- a/src/sms_verification/tests.rs
+++ b/src/sms_verification/tests.rs
@@ -69,7 +69,7 @@ async fn test_service_full_verification_flow(pool: PgPool) {
             "value": phone.as_str()
         },
         "signals": {
-            "ip_address": ip.to_string(),
+            "ip": ip.to_string(),
             "user_agent": user_agent.clone().unwrap()
         },
         "dispatch_id": dispatch_id.clone().unwrap()


### PR DESCRIPTION
`ip` now appears in Prelude requests :+1: 