### PR TITLE
fix: handle empty string for optional URL env vars

### DIFF
--- a/src/infrastructure/config.rs
+++ b/src/infrastructure/config.rs
@@ -42,7 +42,7 @@ pub struct EnvConfig {
     pub lightning_invoice_description: String,
     #[serde(default = "default_ln_verification_enabled")]
     pub ln_verification_enabled: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_url")]
     pub phoenixd_api_url: Option<Url>,
     #[serde(default)]
     pub phoenixd_api_password: String,
@@ -56,6 +56,17 @@ pub struct EnvConfig {
     pub max_ip_verifications_per_week: u32,
     #[serde(default = "default_max_ip_verifications_per_year")]
     pub max_ip_verifications_per_year: u32,
+}
+
+fn deserialize_optional_url<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = serde::Deserialize::deserialize(deserializer)?;
+    if s.is_empty() {
+        return Ok(None);
+    }
+    Url::parse(&s).map(Some).map_err(serde::de::Error::custom)
 }
 
 fn default_allow_cors() -> bool {

--- a/src/infrastructure/config.rs
+++ b/src/infrastructure/config.rs
@@ -17,8 +17,11 @@ pub struct EnvConfig {
     pub sms_verification_enabled: bool,
     #[serde(default)]
     pub prelude_api_key: String,
-    #[serde(default = "default_prelude_api_url")]
-    pub prelude_api_url: Url,
+    #[serde(
+        default = "default_prelude_api_url",
+        deserialize_with = "deserialize_optional_url"
+    )]
+    pub prelude_api_url: Option<Url>,
     pub homeserver_admin_api_url: Url,
     pub homeserver_admin_password: String,
     pub homeserver_pubky: String,
@@ -117,8 +120,8 @@ fn default_lightning_verification_price_sat() -> u64 {
     1000
 }
 
-fn default_prelude_api_url() -> Url {
-    Url::parse("https://api.prelude.dev").expect("Default Prelude API URL is valid")
+fn default_prelude_api_url() -> Option<Url> {
+    Some(Url::parse("https://api.prelude.dev").expect("Default Prelude API URL is valid"))
 }
 
 fn default_http_listen_socker() -> SocketAddr {
@@ -143,7 +146,7 @@ impl EnvConfig {
                 .expect("Default HTTP listen socket is valid"),
             sms_verification_enabled: true,
             prelude_api_key: "test-key".to_string(),
-            prelude_api_url,
+            prelude_api_url: Some(prelude_api_url),
             homeserver_admin_api_url,
             homeserver_admin_password: "test-pass".to_string(),
             homeserver_pubky: "test-homeserver-pubky".to_string(),

--- a/src/sms_verification/app_state.rs
+++ b/src/sms_verification/app_state.rs
@@ -12,7 +12,11 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(config: &EnvConfig, db: SqlDb) -> Self {
-        let prelude_api = PreludeAPI::new(&config.prelude_api_url, &config.prelude_api_key);
+        let prelude_url = config
+            .prelude_api_url
+            .as_ref()
+            .expect("HG_PRELUDE_API_URL is required when SMS verification is enabled");
+        let prelude_api = PreludeAPI::new(prelude_url, &config.prelude_api_key);
         let homeserver_admin_api = HomeserverAdminAPI::new(
             &config.homeserver_admin_api_url,
             &config.homeserver_admin_password,

--- a/src/sms_verification/tests.rs
+++ b/src/sms_verification/tests.rs
@@ -38,7 +38,10 @@ fn create_service_with_mocked_apis(servers: &WiremockServers) -> SmsVerification
         servers.homeserver_server.uri().parse().unwrap(),
     );
 
-    let prelude_api = PreludeAPI::new(&config.prelude_api_url, &config.prelude_api_key);
+    let prelude_api = PreludeAPI::new(
+        config.prelude_api_url.as_ref().unwrap(),
+        &config.prelude_api_key,
+    );
     let homeserver_admin_api = HomeserverAdminAPI::new(
         &config.homeserver_admin_api_url,
         &config.homeserver_admin_password,


### PR DESCRIPTION
Stacked on:
- #20

## Summary
- When `HG_PHOENIXD_API_URL` is unset, docker-compose passes an empty string (`${HG_PHOENIXD_API_URL:-}`), which `envy` tries to parse as a URL, crashing the container with `relative URL without a base: ""`
- Adds a custom deserializer for `Option<Url>` that treats empty strings as `None`

## Test plan
- [x] Run `docker compose up --build` without setting `HG_PHOENIXD_API_URL` — container should start without errors
- [x] Run `curl -X POST http://0.0.0.0:8080/ip_verification` — should return a signup code

🤖 Generated with [Claude Code](https://claude.com/claude-code)